### PR TITLE
Add Chris Henzie as security advisor

### DIFF
--- a/SECURITY_ADVISORS
+++ b/SECURITY_ADVISORS
@@ -17,3 +17,4 @@
 "gooleg-gh","Oleg Mitrofanov","gooleg@google.com","Google"
 "wordsalad","Ross Uhrich","uhr@google.com","Google"
 "cpuguy83", "Brian Goff", "cpuguy83@gmail.com", "Microsoft"
+"chrishenzie","Chris Henzie","chrishenzie@gmail.com","Google"


### PR DESCRIPTION
Chris has already been helping out with the last round of CVEs. Let's add him as a security advisor so he can continue to help.