### PR TITLE
maintainers.yaml: clarify terminology difference across containerd and CNCF

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -7,6 +7,11 @@ see our [CONTRIBUTING.md](./CONTRIBUTING.md) guide.
 
 ## Maintainership
 
+> [!NOTE]
+>
+> "Maintainers" in our terminology has a broader scope than what CNCF recognizes as "Maintainers".
+> Only the "Committers" of the core containerd repository are recognized as "Maintainers" in the CNCF terminology.
+
 There are different types of maintainers, with different responsibilities, but
 all maintainers have 3 things in common:
 

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -3,6 +3,9 @@
 # See GOVERNANCE.md for committer versus reviewer roles
 #
 # COMMITTERS
+#
+# Recognized as "Maintainers" in the CNCF terminology.
+#
 # GitHub ID, Name, Email address,GPG fingerprint
 "AkihiroSuda","Akihiro Suda","akihiro.suda.cz@hco.ntt.co.jp","C020 EA87 6CE4 E06C 7AB9 5AEF 4952 4C6F 9F63 8F1A"
 "dmcgowan","Derek McGowan","derek@mcgstyle.net","8C7A 111C 2110 5794 B0E8 A27B F58C 5D0A 4405 ACDB"
@@ -16,6 +19,9 @@
 "kiashok","Kirtana Ashok","kirtana.ashok@gmail.com",""
 #
 # REVIEWERS
+#
+# Not recognized as "Maintainers" in the CNCF terminology.
+#
 # GitHub ID, Name, Email address, GPG fingerprint
 "jterry75","Justin Terry","jlterry@amazon.com",""
 "cpuguy83","Brian Goff","cpuguy83@gmail.com",""

--- a/maintainers.yaml
+++ b/maintainers.yaml
@@ -7,8 +7,13 @@ maintainers:
   - project_id: "containerd"
     org: "containerd"
     teams:
+      # "project-maintainers" is the name validated by CNCF Automation (https://github.com/cncf/automation).
+      # This team does not exist as a team on GitHub (https://github.com/orgs/containerd/teams).
+      # Note that the GitHub team @containerd/maintainers refers to nearly all the members of the GitHub organization,
+      # including Reviewers, Sub-project Committers, and Sub-project Reviewers.
+      # They are NOT recognized as "Maintainers" in the CNCF terminology.
       - name: "project-maintainers"
-        members:
+        members: &project_maintainers_members
           - dmcgowan
           - estesp
           - AkihiroSuda
@@ -19,3 +24,29 @@ maintainers:
           - kzys
           - samuelkarp
           - kiashok
+      # "Committers" defined in the containerd terminology (see GOVERNANCE.md) are recognized as "Maintainers" in the CNCF terminology.
+      # GitHub team: @containerd/committers
+      - name: "committers"
+        members: *project_maintainers_members
+      # "Reviewers" defined in the containerd terminology are NOT recognized as "Maintainers" in the CNCF terminology.
+      # GitHub team: @containerd/reviewers
+      - name: "reviewers"
+        members:
+          - jterry75
+          - cpuguy83
+          - thajeztah
+          - ktock
+          - dcantah
+          - MikeZappa87
+          - klihub
+          - Iceber
+          - laurazard
+          - henry118
+          - ruiwen-zhao
+          - akhilerm
+          - corhere
+          - austinvazquez
+          - djdongjin
+          - chrishenzie
+          - hsiangkao
+          - vvoland


### PR DESCRIPTION
Alternative to:
- #169